### PR TITLE
Skip compilation in production mode

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -13,8 +13,10 @@ namespace :deploy do
       invoke 'magento:setup:verify'
       invoke 'magento:composer:install'
       invoke 'magento:setup:permissions'
-      invoke 'magento:setup:static-content:deploy'
-      invoke 'magento:setup:di:compile'
+			if fetch(:magento_deploy_production, true)
+				invoke 'magento:setup:static-content:deploy'
+				invoke 'magento:setup:di:compile'
+			end
       invoke 'magento:setup:permissions'
       if test '-d #{current_path}'
         within current_path do


### PR DESCRIPTION
Added a flag named `magento_deploy_production` that is true by default
that allows to skip `setup:static-content:deploy` and `setup:di:compile` commands.

see issue #6
