### PR TITLE
Add capistrano-pending gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Capistrano::Magento2 Change Log
 
+0.3.1
+==========
+
+* Added capistrano-pending gem. Automatically show pending commit message log when deploying. Prompt user if there are no pending changes
+
 0.3.0
 ==========
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ This gem specifies [terminal-notifier](https://rubygems.org/gems/terminal-notifi
 require 'capistrano/magento2/notifier'
 ```
 
+## Pending Changes
+
+This gem specifies [capistrano-pending](https://rubygems.org/gems/capistrano-pending) as a dependency and adds some custom functionality on top of that gem: Any time the `deploy` command is run, a one line summary of git commits that will be deployed will be displayed. If the server(s) you are deploying to already have the latest changes, you will be warned of this and a prompt will appear confirming that you want to continue deploying.
+
 ## Development
 
 After checking out the repo, run `bundle install` to install dependencies. Make the necessary changes, then run `bundle exec rake install` to install a modified version of the gem on your local system.

--- a/capistrano-magento2.gemspec
+++ b/capistrano-magento2.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano', '~> 3.1'
   spec.add_dependency 'terminal-notifier', '~> 1.6'
+  spec.add_dependency 'capistrano-pending', '~> 0.1'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/capistrano/magento2/deploy.rb
+++ b/lib/capistrano/magento2/deploy.rb
@@ -8,6 +8,8 @@
  ##
 
 require 'capistrano/deploy'
+# Explicitly load this file first so the pending commit message log shows before the production confirmation prompt
+require 'capistrano/magento2/pending'
 require 'capistrano/magento2'
 
 load File.expand_path('../../tasks/deploy.rake', __FILE__)

--- a/lib/capistrano/magento2/pending.rb
+++ b/lib/capistrano/magento2/pending.rb
@@ -16,7 +16,11 @@ module Capistrano
 
         # Enhance the native deploy:pending:log command by updating repository and then showing the actual changes that will be deployed
         # Change the log output to oneline for easy reading
-        def log(from, to)
+        # Params:
+        # +from+ - commit-ish to compare from
+        # +to+ - commit-ish to compare to
+        # +returnOutput+ - whether to return or print the output
+        def log(from, to, returnOutput=false)
           run_locally do
             # Ensure repository is up-to-date in order to give an accurate report of pending changes
             execute :git, :fetch, :origin
@@ -28,7 +32,12 @@ module Capistrano
               to = capture(:git, 'rev-parse', '--abbrev-ref', '--symbolic-full-name',  to + '@{u}')
             end
             
-            return capture(:git, :log, "#{from}..#{to}", '--pretty="format:%C(yellow)%h %Cblue%>(12)%ad %Cgreen%<(7)%aN%Cred%d %Creset%s"')
+            output = capture(:git, :log, "#{from}..#{to}", '--pretty="format:%C(yellow)%h %Cblue%>(12)%ad %Cgreen%<(7)%aN%Cred%d %Creset%s"')
+            if returnOutput
+              return output
+            else 
+              puts output
+            end
           end
         end
 

--- a/lib/capistrano/magento2/pending.rb
+++ b/lib/capistrano/magento2/pending.rb
@@ -1,0 +1,40 @@
+##
+ # Copyright © 2016 by David Alger. All rights reserved
+ # 
+ # Licensed under the Open Software License 3.0 (OSL-3.0)
+ # See included LICENSE file for full text of OSL-3.0
+ # 
+ # http://davidalger.com/contact/
+ ##
+
+require "capistrano/pending/scm/base"
+
+module Capistrano
+  module Pending
+    module SCM
+      class Git < Base
+
+        # Enhance the native deploy:pending:log command by updating repository and then showing the actual changes that will be deployed
+        # Change the log output to oneline for easy reading
+        def log(from, to)
+          run_locally do
+            # Ensure repository is up-to-date in order to give an accurate report of pending changes
+            execute :git, :fetch, :origin
+
+            # Since the :branch to deploy from may be behind the upstream branch, get name of upstream branch and use it for comparison.
+            # We are using the test command in case the :branch is set to a specific commit hash, in which case there is no upstream branch.
+            if test(:git, 'rev-parse', '--abbrev-ref', '--symbolic-full-name', to + '@{u}')
+              # Compare against upstream branch, as local branch may be behind.
+              to = capture(:git, 'rev-parse', '--abbrev-ref', '--symbolic-full-name',  to + '@{u}')
+            end
+            
+            return capture(:git, :log, "#{from}..#{to}", '--pretty="format:%C(yellow)%h %Cblue%>(12)%ad %Cgreen%<(7)%aN%Cred%d %Creset%s"')
+          end
+        end
+
+      end
+    end
+  end
+end
+
+load File.expand_path('../../tasks/pending.rake', __FILE__)

--- a/lib/capistrano/magento2/version.rb
+++ b/lib/capistrano/magento2/version.rb
@@ -9,6 +9,6 @@
 
 module Capistrano
   module Magento2
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/lib/capistrano/tasks/pending.rake
+++ b/lib/capistrano/tasks/pending.rake
@@ -11,6 +11,10 @@ namespace :deploy do
   before :starting, 'deploy:pending:check_changes'
   
   namespace :pending do
+    # Wrapper for the log method that sets the return type to return the output rather than output it
+    def _log_return(from, to)
+      _scm.log(from, to, true)
+    end
     
     # Check for pending changes and notify user of incoming changes or warn them that there are no changes
     task :check_changes => :setup do
@@ -19,7 +23,7 @@ namespace :deploy do
         if test "[ -f #{current_path}/REVISION ]"
           from = fetch(:revision)
           to = fetch(:branch)
-          output = _log(from, to)
+          output = _log_return(from, to)
           # TODO: Centralize the notification code between this and deploy:confirm_action
           if output.to_s.strip.empty?
             puts "\e[0;31mNo changes to deploy (from and to are the same: #{from}..#{to}). \nAre you sure you want to continue deploying? [y/N]\e[0m"

--- a/lib/capistrano/tasks/pending.rake
+++ b/lib/capistrano/tasks/pending.rake
@@ -1,0 +1,37 @@
+##
+ # Copyright © 2016 by David Alger. All rights reserved
+ # 
+ # Licensed under the Open Software License 3.0 (OSL-3.0)
+ # See included LICENSE file for full text of OSL-3.0
+ # 
+ # http://davidalger.com/contact/
+ ##
+
+namespace :deploy do
+  before :starting, 'deploy:pending:check_changes'
+  
+  namespace :pending do
+    
+    # Check for pending changes and notify user of incoming changes or warn them that there are no changes
+    task :check_changes => :setup do
+      on roles fetch(:capistrano_pending_role, :app) do |host|
+        # Only check for pending changes if REVISION file exists to prevent error
+        if test "[ -f #{current_path}/REVISION ]"
+          from = fetch(:revision)
+          to = fetch(:branch)
+          output = _log(from, to)
+          # TODO: Centralize the notification code between this and deploy:confirm_action
+          if output.to_s.strip.empty?
+            puts "\e[0;31mNo changes to deploy (from and to are the same: #{from}..#{to}). \nAre you sure you want to continue deploying? [y/N]\e[0m"
+            proceed = STDIN.gets[0..0] rescue nil
+            exit unless proceed == 'y' || proceed == 'Y'
+          else
+            puts "Deploying changes between #{from}..#{to}"
+            puts output
+          end
+        end
+      end
+    end
+  end
+  
+end


### PR DESCRIPTION
This PR implements issue #8

Here is a screenshot of the functionality in action:

![01-18-59 cap cap stage deploy 176x46-jbq71](https://cloud.githubusercontent.com/assets/129031/16293579/ad71f2b0-38e0-11e6-918e-e76e71f07ecd.png)

I didn't have time to centralize the logic that outputs the red prompt messages, but I added a [TODO in the code](https://github.com/erikhansen/capistrano-magento2/blob/feature/capistrano-pending/lib/capistrano/tasks/pending.rake#L23) to do so. I don't think I'll have time to do that in the near future, so hopefully you can merge it in as it is.

I didn't do anything with [point number 2 in my comment](https://github.com/davidalger/capistrano-magento2/issues/8#issuecomment-227886922) on the related issue, as I don't know that it's necessary.
