### PR TITLE
Fixed composer installing non prod dependencies

### DIFF
--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -81,11 +81,11 @@ namespace :magento do
     task :install do
       on release_roles :all do
         within release_path do
-          execute :composer, 'install --prefer-dist --no-interaction 2>&1'
+          execute :composer, 'install --no-dev --prefer-dist --no-interaction 2>&1'
             
           # Dir should be here if properly setup, but check for it anyways just in case
           if test "[ -d #{release_path}/update ]"
-            execute :composer, 'install --prefer-dist --no-interaction -d ./update 2>&1'
+            execute :composer, 'install --no-dev --prefer-dist --no-interaction -d ./update 2>&1'
           else
             puts "\e[0;31m    Warning: ./update dir does not exist in repository!\n\e[0m\n"
           end


### PR DESCRIPTION
The composer flag --no-dev should be used in order to
avoid installing dependencies not necessaries on a production
environment.
