### PR TITLE
Show pending changes before asking user if they want to deploy to a certain stage

### DIFF
--- a/lib/capistrano/tasks/pending.rake
+++ b/lib/capistrano/tasks/pending.rake
@@ -9,9 +9,9 @@
 
 require 'capistrano-pending'
 
+before :deploy, 'deploy:pending:check_changes'
 namespace :deploy do
-  before :starting, 'deploy:pending:check_changes'
-
+    
   namespace :pending do
     # Check for pending changes and notify user of incoming changes or warn them that there are no changes
     task :check_changes => :setup do


### PR DESCRIPTION
This PR changes the behavior of the capistrano-pending functionality. Since 0.5.0, if the capistrano-pending Gem is in use _and_ the `:magento_deploy_confirm` array is configured, the user will be asked to confirm whether they would like to deploy to a certain stage and THEN a list of the changes will be displayed:

![14-25-55 cap -bash 189x80-w5ezs](https://cloud.githubusercontent.com/assets/129031/18449467/e8914b30-78f4-11e6-9653-5dc66379b015.png)

After this PR, the changes are shown before asking if the user wants to deploy. The benefit of this change is that a user can see what changes will be deployed _before_ they decide to proceed (note: this is how this Gem behaved at version 0.4.0):

![14-22-13 cap cap prod deploy 189x80-ydjgy](https://cloud.githubusercontent.com/assets/129031/18449383/8b9c6e28-78f4-11e6-9fe3-deb9fb40cb04.png)
