### PR TITLE
Fix "REVISION file doesn't exist" error when deploying for the first time

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -29,7 +29,7 @@ namespace :deploy do
       end
       invoke 'magento:setup:permissions'
       invoke 'magento:maintenance:enable' if fetch(:magento_deploy_maintenance)
-      if test "[ -d #{current_path} ]"
+      if test "[ -f #{current_path}/bin/magento ]"
         within current_path do
           execute :magento, 'maintenance:enable' if fetch(:magento_deploy_maintenance)
         end

--- a/lib/capistrano/tasks/pending.rake
+++ b/lib/capistrano/tasks/pending.rake
@@ -14,10 +14,11 @@ namespace :deploy do
 
   namespace :pending do
     # Check for pending changes and notify user of incoming changes or warn them that there are no changes
-    task :check_changes => :setup do
+    task :check_changes do
       on roles fetch(:capistrano_pending_role, :app) do |host|
         # check for pending changes only if REVISION file exists to prevent error
         if test "[ -f #{current_path}/REVISION ]"
+          invoke 'deploy:pending:setup'
           from = fetch(:revision)
           to = fetch(:branch)
 


### PR DESCRIPTION
This pull request fixes a "REVISION file doesn't exist" issue when the `capistrano-pending` gem is in use:
![cap -bash 189x58-djy9z](https://cloud.githubusercontent.com/assets/129031/18646498/70066320-7e77-11e6-9b89-df147402b5bb.png)

Technical notes:
- Changed the deploy:pending:check_changes task to NOT be dependent upon
  deploy:pending:setup, as the setup task called through to
  :capture_revision which in turn exited with the above error message
  if the REVISION file didn't exist
- Changed the deploy:pending:check_changes task to explicitly invoke
  deploy:pending:setup after the task does its own check to see if
  REVISION exists
