### PR TITLE
Catch all di:compile errors on 2.1.x

### DIFF
--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -223,12 +223,14 @@ namespace :magento do
             # present in the develop mainline, so we are testing for multi-tenant presence for long-term portability.
             if test :magento, 'setup:di:compile-multi-tenant --help >/dev/null 2>&1'
               output = capture :magento, 'setup:di:compile-multi-tenant', verbosity: Logger::INFO
-              
-              if output.to_s.include? 'Errors during compilation'
-                raise Exception, 'setup:di:compile-multi-tenant command execution failed'
-              end
             else
-              execute :magento, 'setup:di:compile'
+              output = capture :magento, 'setup:di:compile', verbosity: Logger::INFO
+            end
+            
+            # 2.0.x never returns a non-zero exit code for errors, so manually check string
+            # 2.1.x doesn't return a non-zero exit code for certain errors (see davidalger/capistrano-magento2#41)
+            if output.to_s.include? 'Errors during compilation'
+              raise Exception, 'DI compilation command execution failed'
             end
           end
         end


### PR DESCRIPTION
This PR fixes #41

Here is a screenshot demonstrating the fix working on a 2.1.2 site with "soft" di:compile errors:

![17-56-47 new message-sqbvc](https://cloud.githubusercontent.com/assets/129031/20199296/112e2dda-a76f-11e6-84bf-f6832e87933a.png)
