### PR TITLE
Fix issue where setup:static-content:deploy exceptions are ignored

### DIFF
--- a/lib/capistrano/magento2.rb
+++ b/lib/capistrano/magento2.rb
@@ -34,7 +34,7 @@ module Capistrano
     module Setup
       def static_content_deploy params
         output = capture :magento,
-          "setup:static-content:deploy #{params} | stdbuf -o0 tr -d .",
+          "setup:static-content:deploy #{params} | stdbuf -o0 tr -d .; test ${PIPESTATUS[0]} -eq 0",
           verbosity: Logger::INFO
 
         if not output.to_s.include? 'New version of deployed files'


### PR DESCRIPTION
This PR fixes #44

I initially took the approach of checking for the presence of the `[.*Exception]` string, as I suggested in #44. However I couldn't get that to work, and I realized it was because the exception message was getting output as stderr, and it was not getting captured and stored in the [output variable](https://github.com/davidalger/capistrano-magento2/blob/v0.5.6/lib/capistrano/magento2.rb#L36).

After realizing this, I decided to step back and see if there was a better solution. I was surprised that the `bin/magento setup:static-content:deploy` command wasn't returning a non-zero exit code when exceptions were thrown. I decided to test it and found out that the command actually _was_ returning a failure exit code, but piping the output through `stdbuf` resulted in the exit code being masked. 

![08-08-49 new message-grahv](https://cloud.githubusercontent.com/assets/129031/20308745/e97a78f8-ab0a-11e6-91dc-e789b2e4d4a6.png)

In order to check the exit status of the `bin/magento setup:static-content:deploy` command, I added a test of the `$PIPESTATUS` variable:

![08-11-33 new message-c3lm1](https://cloud.githubusercontent.com/assets/129031/20308837/3989b3d6-ab0b-11e6-8208-562b683210db.png)

The only potential issue with this test is that the `$PIPESTATUS` variable is not POSIX-compliant and is specific to sh/bash. I tried adding a check for the existence of `$PIPESTATUS` to prevent issues on other shells, but couldn't get it to work:

```
bin/magento setup:static-content:deploy --theme=ClassyLlama/corporateunited | stdbuf -o0 tr -d .; if [ -n "$PIPESTATUS" ]; then test ${PIPESTATUS[0]} -eq 0; fi
```
