### PR TITLE
Update readme for Capistrano 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ _Note: By default, Capistrano creates "staging" and "production" stages. If you 
     # Load Magento deployment tasks
     require 'capistrano/magento2/deploy'
     
+    # Load Git plugin
+    require "capistrano/scm/git"
+    install_plugin Capistrano::SCM::Git
+    
     # Load custom tasks from `lib/capistrano/tasks` if you have any defined
     Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
     ```


### PR DESCRIPTION
I first tried putting the new plugin require lines _above_ the `# Load Magento deployment tasks` section, but I got this error when doing that:

![21-20-02 new message-3kdwb](https://cloud.githubusercontent.com/assets/129031/21446496/698a36c0-c88c-11e6-864b-27db323d52d2.png)

See https://github.com/capistrano/capistrano/blob/master/UPGRADING-3.7.md for details

Fixes #53