### PR TITLE
Change default magento_deploy_pending_format value to create better alignment of names

### DIFF
--- a/lib/capistrano/magento2/defaults.rb
+++ b/lib/capistrano/magento2/defaults.rb
@@ -61,5 +61,5 @@ set :magento_deploy_pending_role, fetch(:magento_deploy_pending_role, :all)
 set :magento_deploy_pending_warn, fetch(:magento_deploy_pending_warn, true)
 set :magento_deploy_pending_format, fetch(
   :magento_deploy_pending_format,
-  '--pretty="format:%C(yellow)%h %Cblue%>(12)%ad %Cgreen%<(7)%aN%Cred%d %Creset%s"'
+  '--pretty="format:%C(yellow)%h %Cblue%>(12)%ai %Cgreen%<(7)%aN%Cred%d %Creset%s"'
 )


### PR DESCRIPTION
Changing date format to cause names to always be aligned, regardless of whether commits are some single digit or double digit days. Also, the YYYY-MM-DD format is easier to scan than the previous format.

Before:

![before](https://user-images.githubusercontent.com/129031/27669488-96623716-5c4c-11e7-904c-28ed58d0f9a2.png)

After:

![21-57-12 showmecables dev less git log --pretty format c yellow h cblue 12 ai cgreen 7 an cred d creset s 176x48-zqoid](https://user-images.githubusercontent.com/129031/27669534-cab7beaa-5c4c-11e7-87cb-acebf27df355.png)


