### PR TITLE
Fix issue where requiresjs-config.js files were not being generated on Magento 2.1.3+

### DIFF
--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -313,7 +313,7 @@ namespace :magento do
           
           # As of Magento 2.1.3, it became necessary to exclude "--no-javacript" in order for secure versions of 
           # RequireJs configs to be generated
-          if _magento_version <= Gem::Version.new('2.1.3')
+          if _magento_version < Gem::Version.new('2.1.3')
             deploy_flags.push('javascript')
           end
           

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -309,8 +309,15 @@ namespace :magento do
           end
 
           # Run again with HTTPS env var set to 'on' to pre-generate secure versions of RequireJS configs
-          deploy_flags = ['javascript', 'css', 'less', 'images', 'fonts', 'html', 'misc', 'html-minify']
-            .join(' --no-').prepend(' --no-');
+          deploy_flags = ['css', 'less', 'images', 'fonts', 'html', 'misc', 'html-minify']
+          
+          # As of Magento 2.1.3, it became necessary to exclude "--no-javacript" in order for secure versions of 
+          # RequireJs configs to be generated
+          if _magento_version <= Gem::Version.new('2.1.3')
+            deploy_flags.push('javascript')
+          end
+          
+          deploy_flags = deploy_flags.join(' --no-').prepend(' --no-');
 
           # Magento 2.1.0 and earlier lack support for these flags, so generation of secure files requires full re-run
           deploy_flags = nil if _magento_version <= Gem::Version.new('2.1.0')


### PR DESCRIPTION
In version 2.1.0 of Magento, it became necessary to run the `bin/magento setup:static-content:deploy` with the `HTTPS=on` in order for secure versions of the requirejs-config.js file to get generated (e.g., `pub/static/_requirejs/frontend/Magento/blank/en_US/secure/requirejs-config.js`). This Magento core bug was worked around in version of 0.5.0 of this Gem (see [this issue](https://github.com/davidalger/capistrano-magento2/issues/21) for context).

In version 2.1.3 of Magento, the behavior of the `bin/magento setup:static-content:deploy` command changed. In versions 2.1.0-2.1.2, you could pass the following flags and the secure versions of requirejs-config.js would get generated:
```
export HTTPS="on"; bin/magento setup:static-content:deploy --no-javascript --no-ansi en_US --no-css --no-less --no-images --no-fonts --no-html --no-misc --no-html-minify
```

However starting in version 2.1.3, if you passed the `--no-javascript` flag, the secure versions of the requirejs-config.js would never get generated.

This pull requests checks the current version of Magento, and only if the version is between 2.1.0 and 2.1.2 will the `--no-javascript` flag get added.

Let me know if you want to see verification of the behavior difference between 2.1.2 and 2.1.3, although I'm confident of this being the version that the behavior changed as I had an existing 2.1.2 install and installed a vanilla 2.1.3 install just to test this.