### PR TITLE
Added support for Magento 2.2 static content deploy modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Before you can use Capistrano to deploy, you must configure the `config/deploy.r
 | `:magento_deploy_chmod_d`      | `2770` | Default permissions applied to all directories in the release path
 | `:magento_deploy_chmod_f`      | `0660` | Default permissions applied to all non-executable files in the release path
 | `:magento_deploy_chmod_x`      | `['bin/magento']` | Default list of files in release path to set executable bit on
+| `:magento_deploy_static_content_strategy`         | empty  | Magento >= 2.2 static content deploy strategy (can be `quick`, `standard` or `compact`)
 
 #### Example Usage
 

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -311,13 +311,24 @@ namespace :magento do
             deploy_languages = [fetch(:magento_deploy_languages).join(' ')]
           end
 
+					# Magento 2.2 introduces static content compilation strategies that can be one of the following:
+					# quick (default), standard (like previous versions) or compact
+					if _magento_version >= Gem::Version.new('2.2.0')
+						compilation_strategy = fetch(:magento_deploy_static_content_strategy)
+						unless compilation_strategy.empty?
+							compilation_strategy =  " -s #{compilation_strategy} "
+						end
+					else
+						compilation_strategy = ''
+					end
+
           within release_path do
             # Magento 2.1 will fail to deploy if this file does not exist and static asset signing is enabled
             execute "touch #{release_path}/pub/static/deployed_version.txt"
 
             # This loop exists to support deploy on versions where each language must be deployed seperately
             deploy_languages.each do |lang|
-              static_content_deploy "#{deploy_jobs}#{lang}#{deploy_themes}"
+              static_content_deploy "#{compilation_strategy}#{deploy_jobs}#{lang}#{deploy_themes}"
             end
           end
 
@@ -330,7 +341,7 @@ namespace :magento do
             within release_path do with(https: 'on') {
               # This loop exists to support deploy on versions where each language must be deployed seperately
               deploy_languages.each do |lang|
-                static_content_deploy "#{deploy_jobs}#{lang}#{deploy_themes}#{deploy_flags}"
+                static_content_deploy "#{compilation_strategy}#{deploy_jobs}#{lang}#{deploy_themes}#{deploy_flags}"
               end
             } end
           end


### PR DESCRIPTION
In Magento 2.2 there are three types of deploy modes for `static:content:deploy` to be passed with the `-s` opion. Possible values are:

- quick
- standard
- compact

This merge request adds support to the `-s` option through the `:magento_deploy_static_content_mode` variable.

See [here](http://devdocs.magento.com/guides/v2.2/config-guide/cli/config-cli-subcommands-static-view.html) for details about how those strategies work.