### PR TITLE
Optimize set permissions duration

### DIFF
--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -277,8 +277,8 @@ namespace :magento do
     task :permissions do
       on release_roles :all do
         within release_path do
-          execute :find, release_path, "-type d -exec chmod #{fetch(:magento_deploy_chmod_d).to_i} {} +"
-          execute :find, release_path, "-type f -exec chmod #{fetch(:magento_deploy_chmod_f).to_i} {} +"
+          execute :find, release_path, "-type d ! -perm #{fetch(:magento_deploy_chmod_d).to_i} -exec chmod #{fetch(:magento_deploy_chmod_d).to_i} {} +"
+          execute :find, release_path, "-type f ! -perm #{fetch(:magento_deploy_chmod_f).to_i} -exec chmod #{fetch(:magento_deploy_chmod_f).to_i} {} +"
           
           fetch(:magento_deploy_chmod_x).each() do |file|
             execute :chmod, "+x #{release_path}/#{file}"


### PR DESCRIPTION
Add `! -perm #{fetch(:magento_deploy_chmod_f).to_i}` option to find in order to reduce the number of processed files

My experiments seems to show around 25% gain of time, not negligible i think.