### PR TITLE
add flag to composer dump-autoload so deploy does not break using set…

### DIFF
--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -30,7 +30,7 @@ namespace :deploy do
       invoke 'magento:deploy:mode:production'
       invoke 'magento:setup:static-content:deploy'
       invoke 'magento:setup:di:compile'
-      invoke 'magento:composer:dump-autoload'
+      invoke 'magento:composer:dump-autoload' if fetch(:magento_deploy_composer)
     end
     invoke 'magento:setup:permissions'
     invoke 'magento:maintenance:check'


### PR DESCRIPTION
when using set :magento_deploy_composer, false, the composer dump-autoload break deploys. this checks that flag before calling the composer command.