### PR TITLE
Ensure all "execute" commands can be prefixed by SSHKit

### DIFF
--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -195,7 +195,7 @@ namespace :magento do
         on release_roles :all do |host|
           join_paths(shared_path, fetch(:linked_files_touch)).each do |file|
             unless test "[ -f #{file} ]"
-              execute "touch #{file}"
+              execute :touch, file
             end
           end
         end
@@ -360,7 +360,7 @@ namespace :magento do
 
           within release_path do
             # Magento 2.1 will fail to deploy if this file does not exist and static asset signing is enabled
-            execute "touch #{release_path}/pub/static/deployed_version.txt"
+            execute :touch, "#{release_path}/pub/static/deployed_version.txt"
 
             # This loop exists to support deploy on versions where each language must be deployed seperately
             deploy_languages.each do |lang|


### PR DESCRIPTION
https://github.com/FundingCircle/sshkit-backends-netssh_global allows the deployer to run every command as a different user than the one logged into.

For this to work, each command needs to be overridable by SSHKit's [command map](https://github.com/capistrano/sshkit/#the-command-map) which is done by using a symbol for the command name.