### PR TITLE
Clarify documentation for magento_deploy_chmod* settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Before you can use Capistrano to deploy, you must configure the `config/deploy.r
 | `:magento_deploy_no_dev`       | `true` | Enables use of --no-dev flag on composer install
 | `:magento_deploy_maintenance`  | `true` | Enables use of maintenance mode while magento:setup:upgrade runs
 | `:magento_deploy_confirm`      | `[]`   | Used to require confirmation of deployment to a set of capistrano stages
-| `:magento_deploy_chmod_d`      | `2770` | Default permissions applied to all directories in the release path
-| `:magento_deploy_chmod_f`      | `0660` | Default permissions applied to all non-executable files in the release path
+| `:magento_deploy_chmod_d`      | `'2770'` | Default permissions applied to all directories in the release path
+| `:magento_deploy_chmod_f`      | `'0660'` | Default permissions applied to all non-executable files in the release path
 | `:magento_deploy_chmod_x`      | `['bin/magento']` | Default list of files in release path to set executable bit on
 | `:magento_deploy_strategy`     | `nil`  | Can be `quick`, `standard` or `compact`; supported by Magento 2.2 or later
 


### PR DESCRIPTION
If the magento_deploy_chmod* settings are not quoted, any setting that begins with a `0` will not have the expected effect due to how Ruby handles integer conversion using the `to_i` method ([run this](https://repl.it/repls/MotherlyThankfulAmpersand) for an example). [This is where](https://github.com/davidalger/capistrano-magento2/blob/e06fbba5d9a5c0e4225c835237b55a29a0dbb091/lib/capistrano/tasks/magento.rake#L306) `to_i` is used in this Gem. 

For example, if you add this setting in `config/deploy.rb`:

```
set :magento_deploy_chmod_f, 0660
```

Then the `magento:setup:permissions` command will use `432` instead of `660`

```
find /var/www/stage.example.com/releases/20190828215809 -type f ! -perm 432 -exec chmod 432 {} +
```

But if you set the value as a string, it works as expected:

```
set :magento_deploy_chmod_f, '0660'
```


```
find /var/www/stage.example.com/releases/20190828215809 -type f ! -perm 660 -exec chmod 660 {} +
```