### PR TITLE
Drop Support for EOL Magento Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ lock '~> 3.14'
 * Dropped explicit default of `:magento_deploy_languages`; will now only be passed to `bin/magento` call when set in project configuration.
 * Updated zero-down deployment logic to rely on `app:config:status` to detect config changes rather than the md5sum of config.php in current and release directories.
 * Added `magento:app:config:status` to available commands for manual execution.
+* Fixes issue in 2.3.4 and later where app:config:import may fail if cache:flush is not run immediately prior ([issue #138](https://github.com/davidalger/capistrano-magento2/issues/138))
 
 0.8.9
 =========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ lock '~> 3.14'
 * Removed `magento:deploy:version_check` task and associated warning when attempting to deploy unsupported versions of Magento
 * Updated required version of `capistrano` to `~> 1.13` (>=1.13 and less than 2.0)
 * Resolved inability to use `--dry-run` flag ([issue #128](https://github.com/davidalger/capistrano-magento2/issues/128)) as made possible by the removal of all version related gating logic.
+* Dropped explicit default of `:magento_deploy_languages`; will now only be passed to `bin/magento` call when set in project configuration.
 
 0.8.9
 =========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,29 @@
 0.9.0
 =========
 
-* **Dropped support for versions of Magento prior to 2.3.0** as they are well past their EOL by now
-* Cleanup of all `version_check` related gating logic around legacy behaviors in 2.1.x and 2.2.x
+**Upgrade Notes:**
+
+As of this release only Magento 2.3 and later are supported and **support has been dropped for prior versions** which have long since reached their end-of-life. This version likely works with 2.2.2 and later, but as 2.2 is officially EOL it will no longer be supported by new releases of this gem.
+
+If using a `Gemfile` with Bundler to lock versions of dependencies used for execution, the version lock on `capistrano` should be updated to `~>1.13` to match the minimal requirement of this release, otherwise `bundle update` will fail to update to version `0.9.0` of this gem. The following is recommended:
+
+```
+gem 'capistrano', '~> 3.14'
+gem 'capistrano-magento2', '~> 0.9'
+```
+
+If a capistrano version lock is present in a projects `deploy.rb` it will also need to be updated:
+
+```
+lock '~> 3.14'
+```
+
+**Change Summary:**
+
+* Dropped support for EOL versions of Magento and scrubbed all gated logic around legacy behaviors in 2.1.x and 2.2.x
 * Removed `magento:deploy:version_check` task and associated warning when attempting to deploy unsupported versions of Magento
-* Updated required version of `capistrano` to `~> 1.13` (>1.13 and less than 2.0)
-* Resolved inability to use `--dry-run` flag (issue #128); direct result of removing all version related gating logic.
+* Updated required version of `capistrano` to `~> 1.13` (>=1.13 and less than 2.0)
+* Resolved inability to use `--dry-run` flag ([issue #128](https://github.com/davidalger/capistrano-magento2/issues/128)) as made possible by the removal of all version related gating logic.
 
 0.8.9
 =========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ lock '~> 3.14'
 * Resolved inability to use `--dry-run` flag ([issue #128](https://github.com/davidalger/capistrano-magento2/issues/128)) as made possible by the removal of all version related gating logic.
 * Dropped explicit default of `:magento_deploy_languages`; will now only be passed to `bin/magento` call when set in project configuration.
 * Updated zero-down deployment logic to rely on `app:config:status` to detect config changes rather than the md5sum of config.php in current and release directories.
+* Added `magento:app:config:status` to available commands for manual execution.
 
 0.8.9
 =========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ lock '~> 3.14'
 * Updated required version of `capistrano` to `~> 1.13` (>=1.13 and less than 2.0)
 * Resolved inability to use `--dry-run` flag ([issue #128](https://github.com/davidalger/capistrano-magento2/issues/128)) as made possible by the removal of all version related gating logic.
 * Dropped explicit default of `:magento_deploy_languages`; will now only be passed to `bin/magento` call when set in project configuration.
+* Updated zero-down deployment logic to rely on `app:config:status` to detect config changes rather than the md5sum of config.php in current and release directories.
 
 0.8.9
 =========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 0.9.0
 =========
 
-* Updated required version of `capistrano` to `~> 1.13`
+* **Dropped support for versions of Magento prior to 2.3.0** as they are well past their EOL by now
+* Cleanup of all `version_check` related gating logic around legacy behaviors in 2.1.x and 2.2.x
+* Removed `magento:deploy:version_check` task and associated warning when attempting to deploy unsupported versions of Magento
+* Updated required version of `capistrano` to `~> 1.13` (>1.13 and less than 2.0)
+* Resolved inability to use `--dry-run` flag (issue #128); direct result of removing all version related gating logic.
 
 0.8.9
 =========

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Capistrano::Magento2 Change Log
 
+0.9.0
+=========
+
+* Updated required version of `capistrano` to `~> 1.13`
+
 0.8.9
 =========
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 **Upgrade Notes:**
 
-As of this release only Magento 2.3 and later are supported and **support has been dropped for prior versions** which have long since reached their end-of-life. This version likely works with 2.2.2 and later, but as 2.2 is officially EOL it will no longer be supported by new releases of this gem.
+As of this release only Magento 2.3 and later are supported and **support has been dropped for prior versions** which have long since reached their end-of-life. Moving forward versions past their EOL will no longer be supported by subsequent releases of this gem. Older versions of this gem may continue to be used to deploy older and EOL versions.
 
 If using a `Gemfile` with Bundler to lock versions of dependencies used for execution, the version lock on `capistrano` should be updated to `~>1.13` to match the minimal requirement of this release, otherwise `bundle update` will fail to update to version `0.9.0` of this gem. The following is recommended:
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ For the sake of simplicity in new project setups `:linked_dirs` and `:linked_fil
 ```ruby
 set :linked_files, [
   'app/etc/env.php',
-  'app/etc/config.local.php',
   'var/.setup_cronjob_status',
   'var/.update_cronjob_status'
 ]
@@ -177,8 +176,6 @@ If you would like to customize the linked files or directories for your project,
 ```ruby
 append :linked_dirs, 'path/to/link'
 ```
-
-Support for a `app/etc/config.local.php` configuration file was added to Magento 2.1.6. This file will be linked in from the `shared/app/etc` directory as of v0.6.4 of this gem. If this file is present in the project repository, the file will not be linked.
 
 ### Composer Auth Credentials
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Before you can use Capistrano to deploy, you must configure the `config/deploy.r
 | `:magento_deploy_chmod_d`      | `'2770'` | Default permissions applied to all directories in the release path
 | `:magento_deploy_chmod_f`      | `'0660'` | Default permissions applied to all non-executable files in the release path
 | `:magento_deploy_chmod_x`      | `['bin/magento']` | Default list of files in release path to set executable bit on
-| `:magento_deploy_strategy`     | `nil`  | Can be `quick`, `standard` or `compact`; supported by Magento 2.2 or later
+| `:magento_deploy_strategy`     | `nil`  | Can be `quick`, `standard` or `compact`
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Before you can use Capistrano to deploy, you must configure the `config/deploy.r
 | `:magento_deploy_cache_shared` | `true`  | If true, cache operations are restricted to the primary node in setup role
 | `:magento_deploy_languages`    | `[]` | Array of languages passed to static content deploy routine
 | `:magento_deploy_themes`       | `[]`   | Array of themes passed to static content deploy
-| `:magento_deploy_jobs`         | `4`    | Number of threads to use for static content deploy
+| `:magento_deploy_jobs`         | `nil`    | Number of threads to use for static content deploy
 | `:magento_deploy_composer`     | `true` | Enables composer install behaviour in the built-in deploy routine
 | `:magento_deploy_production`   | `true` | Enables production specific DI compilation and static content generation
 | `:magento_deploy_no_dev`       | `true` | Enables use of --no-dev flag on composer install
@@ -141,10 +141,8 @@ Add a line similar to the following in `config/deploy.rb` to set a custom value 
 
 ```ruby
 set :magento_deploy_languages, ['en_US', 'en_CA']
-```
-
-```ruby
 set :magento_deploy_composer, false
+set :magento_deploy_jobs, 4
 ```
 
 ### Capistrano Built-Ins

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Before you can use Capistrano to deploy, you must configure the `config/deploy.r
 | ------------------------------ | ------- | ---
 | `:magento_deploy_setup_role`   | `:all`  | Role from which primary host is chosen to run things like setup:upgrade on
 | `:magento_deploy_cache_shared` | `true`  | If true, cache operations are restricted to the primary node in setup role
-| `:magento_deploy_languages`    | `['en_US']` | Array of languages passed to static content deploy routine
+| `:magento_deploy_languages`    | `[]` | Array of languages passed to static content deploy routine
 | `:magento_deploy_themes`       | `[]`   | Array of themes passed to static content deploy
 | `:magento_deploy_jobs`         | `4`    | Number of threads to use for static content deploy
 | `:magento_deploy_composer`     | `true` | Enables composer install behaviour in the built-in deploy routine

--- a/README.md
+++ b/README.md
@@ -118,22 +118,22 @@ Before you can use Capistrano to deploy, you must configure the `config/deploy.r
 
 ### Magento Deploy Settings
 
-| setting                        | default | what it does
-| ------------------------------ | ------- | ---
-| `:magento_deploy_setup_role`   | `:all`  | Role from which primary host is chosen to run things like setup:upgrade on
-| `:magento_deploy_cache_shared` | `true`  | If true, cache operations are restricted to the primary node in setup role
-| `:magento_deploy_languages`    | `[]` | Array of languages passed to static content deploy routine
-| `:magento_deploy_themes`       | `[]`   | Array of themes passed to static content deploy
+| setting                        | default  | what it does
+| ------------------------------ | -------- | ---
+| `:magento_deploy_setup_role`   | `:all`   | Role from which primary host is chosen to run things like setup:upgrade on
+| `:magento_deploy_cache_shared` | `true`   | If true, cache operations are restricted to the primary node in setup role
+| `:magento_deploy_languages`    | `[]`     | Array of languages passed to static content deploy routine
+| `:magento_deploy_themes`       | `[]`     | Array of themes passed to static content deploy
 | `:magento_deploy_jobs`         | `nil`    | Number of threads to use for static content deploy
-| `:magento_deploy_composer`     | `true` | Enables composer install behaviour in the built-in deploy routine
-| `:magento_deploy_production`   | `true` | Enables production specific DI compilation and static content generation
-| `:magento_deploy_no_dev`       | `true` | Enables use of --no-dev flag on composer install
-| `:magento_deploy_maintenance`  | `true` | Enables use of maintenance mode while magento:setup:upgrade runs
-| `:magento_deploy_confirm`      | `[]`   | Used to require confirmation of deployment to a set of capistrano stages
+| `:magento_deploy_composer`     | `true`   | Enables composer install behavior in the built-in deploy routine
+| `:magento_deploy_production`   | `true`   | Enables production specific DI compilation and static content generation
+| `:magento_deploy_no_dev`       | `true`   | Enables use of --no-dev flag on composer install
+| `:magento_deploy_maintenance`  | `true`   | Enables use of maintenance mode while magento:setup:upgrade runs
+| `:magento_deploy_confirm`      | `[]`     | Used to require confirmation of deployment to a set of capistrano stages
 | `:magento_deploy_chmod_d`      | `'2770'` | Default permissions applied to all directories in the release path
 | `:magento_deploy_chmod_f`      | `'0660'` | Default permissions applied to all non-executable files in the release path
 | `:magento_deploy_chmod_x`      | `['bin/magento']` | Default list of files in release path to set executable bit on
-| `:magento_deploy_strategy`     | `nil`  | Can be `quick`, `standard` or `compact`
+| `:magento_deploy_strategy`     | `nil`    | Can be `quick`, `standard` or `compact`
 
 #### Example Usage
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ Before you can use Capistrano to deploy, you must configure the `config/deploy.r
 Add a line similar to the following in `config/deploy.rb` to set a custom value on one of the above settings:
 
 ```ruby
+set :magento_deploy_jobs, '$(nproc)'
+set :magento_deploy_themes, ['Magento/backend', 'Magento/blank']
 set :magento_deploy_languages, ['en_US', 'en_CA']
-set :magento_deploy_composer, false
-set :magento_deploy_jobs, 4
 ```
 
 ### Capistrano Built-Ins

--- a/capistrano-magento2.gemspec
+++ b/capistrano-magento2.gemspec
@@ -27,8 +27,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'capistrano', '~> 3.1'
+  spec.add_dependency 'capistrano', '~> 3.14'
 
-  spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 13.0'
 end

--- a/lib/capistrano/magento2.rb
+++ b/lib/capistrano/magento2.rb
@@ -34,24 +34,6 @@ module Capistrano
     end
 
     module Setup
-      def static_content_deploy params
-        if magento_version >= Gem::Version.new('2.2.0-rc')
-          # Using -f here just in case MAGE_MODE environment variable in shell is set to something other than production
-          execute :magento, "setup:static-content:deploy -f #{params}"
-        else
-          # Sets pipefail option in shell allowing command exit codes to halt execution when piping command output
-          if not SSHKit.config.command_map[:magento].include? 'set -o pipefail' # avoids trouble on multi-host deploys
-            @@pipefail_less = SSHKit.config.command_map[:magento].dup
-            SSHKit.config.command_map[:magento] = "set -o pipefail; #{@@pipefail_less}"
-          end
-
-          execute :magento, "setup:static-content:deploy #{params} | stdbuf -o0 tr -d ."
-
-          # Unsets pipefail option in shell so it won't affect future command executions
-          SSHKit.config.command_map[:magento] = @@pipefail_less
-        end
-      end
-
       def deployed_version
         # Generate a static content version string, but only if one has not already been set on a previous call
         if not fetch(:magento_static_deployed_version)

--- a/lib/capistrano/magento2.rb
+++ b/lib/capistrano/magento2.rb
@@ -14,10 +14,6 @@ SSHKit.config.command_map[:magento] = "/usr/bin/env php -f bin/magento --"
 module Capistrano
   module Magento2
     module Helpers
-      def magento_version
-        return Gem::Version::new((capture :php, "-f #{release_path}/bin/magento -- -V --no-ansi").split(' ').pop)
-      end
-
       def disabled_modules
         output = capture :magento, 'module:status --no-ansi'
         output = output.split("disabled modules:\n", 2)[1]

--- a/lib/capistrano/magento2/defaults.rb
+++ b/lib/capistrano/magento2/defaults.rb
@@ -45,7 +45,7 @@ set :magento_deploy_chmod_x, fetch(:magento_deploy_chmod_x, ['bin/magento'])
 # deploy configuration defaults
 set :magento_deploy_composer, fetch(:magento_deploy_composer, true)
 set :magento_deploy_confirm, fetch(:magento_deploy_confirm, [])
-set :magento_deploy_languages, fetch(:magento_deploy_languages, ['en_US'])
+set :magento_deploy_languages, fetch(:magento_deploy_languages, [])
 set :magento_deploy_maintenance, fetch(:magento_deploy_maintenance, true)
 set :magento_deploy_production, fetch(:magento_deploy_production, true)
 set :magento_deploy_no_dev, fetch(:magento_deploy_no_dev, true)

--- a/lib/capistrano/magento2/defaults.rb
+++ b/lib/capistrano/magento2/defaults.rb
@@ -9,14 +9,12 @@
 
 set :linked_files, fetch(:linked_files, []).push(
   'app/etc/env.php',
-  'app/etc/config.local.php',
   'var/.setup_cronjob_status',
   'var/.update_cronjob_status'
 )
 
 set :linked_files_touch, fetch(:linked_files_touch, []).push(
   'app/etc/env.php',
-  'app/etc/config.local.php',
   'var/.setup_cronjob_status',
   'var/.update_cronjob_status'
 )

--- a/lib/capistrano/magento2/defaults.rb
+++ b/lib/capistrano/magento2/defaults.rb
@@ -51,7 +51,7 @@ set :magento_deploy_production, fetch(:magento_deploy_production, true)
 set :magento_deploy_no_dev, fetch(:magento_deploy_no_dev, true)
 set :magento_deploy_themes, fetch(:magento_deploy_themes, [])
 set :magento_deploy_jobs, fetch(:magento_deploy_jobs, nil)      # this defaults to 4 when supported by bin/magento
-set :magento_deploy_strategy, fetch(:magento_deploy_strategy, nil)  # Magento 2.2 or later only: http://bit.ly/2yhMvVv
+set :magento_deploy_strategy, fetch(:magento_deploy_strategy, nil)
 
 # deploy targetting defaults
 set :magento_deploy_setup_role, fetch(:magento_deploy_setup_role, :all)

--- a/lib/capistrano/magento2/defaults.rb
+++ b/lib/capistrano/magento2/defaults.rb
@@ -50,7 +50,7 @@ set :magento_deploy_maintenance, fetch(:magento_deploy_maintenance, true)
 set :magento_deploy_production, fetch(:magento_deploy_production, true)
 set :magento_deploy_no_dev, fetch(:magento_deploy_no_dev, true)
 set :magento_deploy_themes, fetch(:magento_deploy_themes, [])
-set :magento_deploy_jobs, fetch(:magento_deploy_jobs, nil)      # this defaults to 4 when supported by bin/magento
+set :magento_deploy_jobs, fetch(:magento_deploy_jobs, nil)
 set :magento_deploy_strategy, fetch(:magento_deploy_strategy, nil)
 
 # deploy targetting defaults

--- a/lib/capistrano/magento2/version.rb
+++ b/lib/capistrano/magento2/version.rb
@@ -9,6 +9,6 @@
 
 module Capistrano
   module Magento2
-    VERSION = '0.8.9'
+    VERSION = '0.9.0'
   end
 end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -11,7 +11,6 @@ include Capistrano::Magento2::Helpers
 
 namespace :deploy do
   before 'deploy:check:linked_files', 'magento:deploy:check'
-  before 'deploy:symlink:linked_files', 'magento:deploy:local_config'
 
   # If both 'scopes' and 'themes' are available in app/etc/config.php then the build should not require database or
   # cache backend configuration to deploy. Removing the link to app/etc/env.php in this case prevents any possible

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -83,7 +83,7 @@ namespace :deploy do
       within release_path do
         _disabled_modules = disabled_modules
         if _disabled_modules.count > 0
-          info "\nThe following modules are disabled per app/etc/config.php:\n"
+          info "\n\nThe following modules are disabled per app/etc/config.php:\n"
           _disabled_modules.each do |module_name|
             info '- ' + module_name
           end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -75,14 +75,7 @@ namespace :deploy do
       end
     end
 
-    on primary fetch(:magento_deploy_setup_role) do
-      within release_path do
-        if not fetch(:magento_internal_zero_down_flag)
-          invoke 'magento:app:config:import'
-        end
-      end
-    end
-
+    invoke 'magento:app:config:import' if not fetch(:magento_internal_zero_down_flag)
     invoke 'magento:setup:db:schema:upgrade' if not fetch(:magento_internal_zero_down_flag)
     invoke 'magento:setup:db:data:upgrade' if not fetch(:magento_internal_zero_down_flag)
 

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -75,13 +75,10 @@ namespace :deploy do
       end
     end
 
-    # The app:config:import command was introduced in 2.2.0; check if it exists before invoking it
     on primary fetch(:magento_deploy_setup_role) do
       within release_path do
-        if test :magento, 'app:config:import --help >/dev/null 2>&1'
-          if not fetch(:magento_internal_zero_down_flag)
-            invoke 'magento:app:config:import'
-          end
+        if not fetch(:magento_internal_zero_down_flag)
+          invoke 'magento:app:config:import'
         end
       end
     end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -84,7 +84,7 @@ namespace :deploy do
       within release_path do
         _disabled_modules = disabled_modules
         if _disabled_modules.count > 0
-          info "\n\nThe following modules are disabled per app/etc/config.php:\n"
+          info "\nThe following modules are disabled per app/etc/config.php:\n"
           _disabled_modules.each do |module_name|
             info '- ' + module_name
           end

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -49,7 +49,6 @@ namespace :deploy do
   task :updated do
     invoke 'magento:deploy:verify'
     invoke 'magento:composer:install' if fetch(:magento_deploy_composer)
-    invoke 'magento:deploy:version_check'
     invoke 'magento:setup:permissions'
 
     if fetch(:magento_deploy_production)

--- a/lib/capistrano/tasks/deploy.rake
+++ b/lib/capistrano/tasks/deploy.rake
@@ -75,6 +75,7 @@ namespace :deploy do
       end
     end
 
+    invoke 'magento:cache:flush' if not fetch(:magento_internal_zero_down_flag)
     invoke 'magento:app:config:import' if not fetch(:magento_internal_zero_down_flag)
     invoke 'magento:setup:db:schema:upgrade' if not fetch(:magento_internal_zero_down_flag)
     invoke 'magento:setup:db:data:upgrade' if not fetch(:magento_internal_zero_down_flag)

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -314,15 +314,15 @@ namespace :magento do
         on release_roles :all do
           with mage_mode: :production do
             deploy_languages = fetch(:magento_deploy_languages)
-            if deploy_languages
-              deploy_languages = deploy_languages.join(' ')
+            if deploy_languages.count() > 0
+              deploy_languages = deploy_languages.join(' -l ').prepend('-l ')
             else
               deploy_languages = nil
             end
 
             deploy_themes = fetch(:magento_deploy_themes)
             if deploy_themes.count() > 0
-              deploy_themes = deploy_themes.join(' -t ').prepend(' -t ')
+              deploy_themes = deploy_themes.join(' -t ').prepend('-t ')
             else
               deploy_themes = nil
             end

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -305,12 +305,7 @@ namespace :magento do
         on release_roles :all do
           within release_path do
             with mage_mode: :production do
-              output = capture :magento, 'setup:di:compile --no-ansi', verbosity: Logger::INFO
-
-              # 2.1.x doesn't return a non-zero exit code for certain errors (see davidalger/capistrano-magento2#41)
-              if output.to_s.include? 'Errors during compilation'
-                raise Exception, 'DI compilation command execution failed'
-              end
+              execute :magento, "setup:di:compile"
             end
           end
         end

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -369,7 +369,8 @@ namespace :magento do
               # Magento 2.1 will fail to deploy if this file does not exist and static asset signing is enabled
               execute :touch, "#{release_path}/pub/static/deployed_version.txt"
 
-              static_content_deploy "#{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
+              # Using -f here just in case MAGE_MODE environment variable in shell is set to something other than production
+              execute :magento, "setup:static-content:deploy -f #{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
             end
 
             # Set the deployed_version of static content to ensure it matches across all hosts

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -31,6 +31,15 @@ namespace :magento do
           end
         end
       end
+      
+      desc 'Checks if config propagation requires update'
+      task :status do
+        on primary fetch(:magento_deploy_setup_role) do
+          within release_path do
+            execute :magento, 'app:config:status'
+          end
+        end
+      end
     end
   end
 
@@ -234,7 +243,7 @@ namespace :magento do
     end
     
     namespace :db do
-      desc 'Checks if database schema and/or data require upgrading'
+      desc 'Checks if DB schema or data requires upgrade'
       task :status do
         on primary fetch(:magento_deploy_setup_role) do
           within release_path do

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -424,11 +424,11 @@ namespace :magento do
 
           if config_status.to_s.include? 'Config files are up to date'
             info "Config files are up to date."
-            info ""
             config_uptodate = true
           else
             puts "      #{config_status.gsub("\n", "\n      ").sub(" Run app:config:import or setup:upgrade command to synchronize configuration.", "")}"
           end
+          info ""
 
           # If both checks above reported up-to-date status checks disable maintenance mode
           if database_uptodate and config_uptodate

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -342,9 +342,6 @@ namespace :magento do
             end
 
             within release_path do
-              # Magento 2.1 will fail to deploy if this file does not exist and static asset signing is enabled
-              execute :touch, "#{release_path}/pub/static/deployed_version.txt"
-
               # Using -f here just in case MAGE_MODE environment variable in shell is set to something other than production
               execute :magento, "setup:static-content:deploy -f #{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
             end

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -231,17 +231,6 @@ namespace :magento do
       end
       exit 1 if is_err
     end
-
-    task :local_config do
-      on release_roles :all do
-        if test "[ -f #{release_path}/app/etc/config.local.php ]"
-          info "The repository contains app/etc/config.local.php, removing from :linked_files list."
-          _linked_files = fetch(:linked_files, [])
-          _linked_files.delete('app/etc/config.local.php')
-          set :linked_files, _linked_files
-        end
-      end
-    end
   end
 
   namespace :setup do

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -339,6 +339,7 @@ namespace :magento do
           with mage_mode: :production do
             _magento_version = magento_version
 
+            deploy_languages = fetch(:magento_deploy_languages).join(' ')
             deploy_themes = fetch(:magento_deploy_themes)
             deploy_jobs = fetch(:magento_deploy_jobs)
 
@@ -354,14 +355,6 @@ namespace :magento do
               deploy_jobs = nil
             end
 
-            # Workaround core-bug with multi-lingual deployments on Magento 2.1.3 and greater. In these versions each
-            # language must be iterated individually. See issue #72 for details.
-            if _magento_version >= Gem::Version.new('2.1.3')
-              deploy_languages = fetch(:magento_deploy_languages)
-            else
-              deploy_languages = [fetch(:magento_deploy_languages).join(' ')]
-            end
-
             # Magento 2.2 introduced static content compilation strategies that can be one of the following:
             # quick (default), standard (like previous versions) or compact
             compilation_strategy = fetch(:magento_deploy_strategy)
@@ -375,10 +368,7 @@ namespace :magento do
               # Magento 2.1 will fail to deploy if this file does not exist and static asset signing is enabled
               execute :touch, "#{release_path}/pub/static/deployed_version.txt"
 
-              # This loop exists to support deploy on versions where each language must be deployed seperately
-              deploy_languages.each do |lang|
-                static_content_deploy "#{compilation_strategy}#{deploy_jobs}#{lang}#{deploy_themes}"
-              end
+              static_content_deploy "#{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
             end
 
             # Set the deployed_version of static content to ensure it matches across all hosts

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -315,21 +315,21 @@ namespace :magento do
           with mage_mode: :production do
             deploy_languages = fetch(:magento_deploy_languages)
             if deploy_languages.count() > 0
-              deploy_languages = deploy_languages.join(' -l ').prepend('-l ')
+              deploy_languages = deploy_languages.join(' -l ').prepend(' -l ')
             else
               deploy_languages = nil
             end
 
             deploy_themes = fetch(:magento_deploy_themes)
             if deploy_themes.count() > 0
-              deploy_themes = deploy_themes.join(' -t ').prepend('-t ')
+              deploy_themes = deploy_themes.join(' -t ').prepend(' -t ')
             else
               deploy_themes = nil
             end
 
             deploy_jobs = fetch(:magento_deploy_jobs)
             if deploy_jobs
-              deploy_jobs = "--jobs #{deploy_jobs} "
+              deploy_jobs = " --jobs #{deploy_jobs}"
             else
               deploy_jobs = nil
             end
@@ -338,11 +338,11 @@ namespace :magento do
             # quick (default), standard (like previous versions) or compact
             compilation_strategy = fetch(:magento_deploy_strategy)
             if compilation_strategy
-              compilation_strategy =  "-s #{compilation_strategy} "
+              compilation_strategy =  " -s #{compilation_strategy}"
             end
 
             within release_path do
-              execute :magento, "setup:static-content:deploy #{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
+              execute :magento, "setup:static-content:deploy#{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
             end
 
             # Set the deployed_version of static content to ensure it matches across all hosts

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -334,7 +334,7 @@ namespace :magento do
               deploy_jobs = nil
             end
 
-            # Magento 2.2 introduced static content compilation strategies that can be one of the following:
+            # Static content compilation strategies that can be one of the following:
             # quick (default), standard (like previous versions) or compact
             compilation_strategy = fetch(:magento_deploy_strategy)
             if compilation_strategy

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -436,12 +436,12 @@ namespace :magento do
           end
 
           if maintenance_enabled
-            info "Maintenance mode was already active prior to deploy."
             info "Disabling maintenance mode management..."
+            info "Maintenance mode was already active prior to deploy."
             set :magento_deploy_maintenance, false
           elsif disable_maintenance
-            info "There are no database updates or config changes. This is a zero-down deployment."
             info "Disabling maintenance mode management..."
+            info "There are no database updates or config changes. This is a zero-down deployment."
             set :magento_internal_zero_down_flag, true # Set internal flag to stop db schema/data upgrades from running
             set :magento_deploy_maintenance, false     # Disable maintenance mode management since it is not neccessary
           else

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -51,6 +51,7 @@ namespace :magento do
           execute :magento, 'cache:flush'
         end
       end
+      Rake::Task['magento:cache:flush'].reenable  ## make task perpetually callable
     end
     
     desc 'Clean Magento cache by types'

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -342,8 +342,7 @@ namespace :magento do
             end
 
             within release_path do
-              # Using -f here just in case MAGE_MODE environment variable in shell is set to something other than production
-              execute :magento, "setup:static-content:deploy -f #{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
+              execute :magento, "setup:static-content:deploy #{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
             end
 
             # Set the deployed_version of static content to ensure it matches across all hosts

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -337,18 +337,21 @@ namespace :magento do
       task :deploy do
         on release_roles :all do
           with mage_mode: :production do
-            _magento_version = magento_version
+            deploy_languages = fetch(:magento_deploy_languages)
+            if deploy_languages
+              deploy_languages = deploy_languages.join(' ')
+            else
+              deploy_languages = nil
+            end
 
-            deploy_languages = fetch(:magento_deploy_languages).join(' ')
             deploy_themes = fetch(:magento_deploy_themes)
-            deploy_jobs = fetch(:magento_deploy_jobs)
-
             if deploy_themes.count() > 0
               deploy_themes = deploy_themes.join(' -t ').prepend(' -t ')
             else
               deploy_themes = nil
             end
 
+            deploy_jobs = fetch(:magento_deploy_jobs)
             if deploy_jobs
               deploy_jobs = "--jobs #{deploy_jobs} "
             else
@@ -358,10 +361,8 @@ namespace :magento do
             # Magento 2.2 introduced static content compilation strategies that can be one of the following:
             # quick (default), standard (like previous versions) or compact
             compilation_strategy = fetch(:magento_deploy_strategy)
-            if compilation_strategy and _magento_version >= Gem::Version.new('2.2.0')
+            if compilation_strategy
               compilation_strategy =  "-s #{compilation_strategy} "
-            else
-              compilation_strategy = nil
             end
 
             within release_path do

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -381,20 +381,6 @@ namespace :magento do
               end
             end
 
-            # Run again with HTTPS env var set to 'on' to pre-generate secure versions of RequireJS configs. A
-            # single run on these Magento versions will fail to generate the secure requirejs-config.js file.
-            if _magento_version < Gem::Version.new('2.1.8')
-              deploy_flags = ['css', 'less', 'images', 'fonts', 'html', 'misc', 'html-minify']
-                .join(' --no-').prepend(' --no-');
-
-              within release_path do with(https: 'on') {
-                # This loop exists to support deploy on versions where each language must be deployed seperately
-                deploy_languages.each do |lang|
-                  static_content_deploy "#{compilation_strategy}#{deploy_jobs}#{lang}#{deploy_themes}#{deploy_flags}"
-                end
-              } end
-            end
-
             # Set the deployed_version of static content to ensure it matches across all hosts
             upload!(StringIO.new(deployed_version), "#{release_path}/pub/static/deployed_version.txt")
           end

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -184,19 +184,6 @@ namespace :magento do
       end
     end
 
-    task :version_check do
-      on release_roles(:all), in: :sequence, wait: 1 do
-        within release_path do
-          _magento_version = magento_version
-          unless _magento_version >= Gem::Version.new('2.1.1')
-            error "\e[0;31mVersion 0.7.0 and later of this gem only support deployment of Magento 2.1.1 or newer; " +
-              "attempted to deploy v" + _magento_version.to_s + ". Please try again using an earlier version of this gem!\e[0m"
-            exit 1  # only need to check a single server, exit immediately
-          end
-        end
-      end
-    end
-
     task :check do
       on release_roles :all do
         next unless any? :linked_files_touch


### PR DESCRIPTION
**Change Summary:**

* Dropped support for EOL versions of Magento and scrubbed all gated logic around legacy behaviors in 2.1.x and 2.2.x
* Removed `magento:deploy:version_check` task and associated warning when attempting to deploy unsupported versions of Magento
* Updated required version of `capistrano` to `~> 1.13` (>=1.13 and less than 2.0)
* Resolved inability to use `--dry-run` flag ([issue #128](https://github.com/davidalger/capistrano-magento2/issues/128)) as made possible by the removal of all version related gating logic.
* Dropped explicit default of `:magento_deploy_languages`; will now only be passed to `bin/magento` call when set in project configuration.
* Updated zero-down deployment logic to rely on `app:config:status` to detect config changes rather than the md5sum of config.php in current and release directories.
* Added `magento:app:config:status` to available commands for manual execution.
* Fixes issue in 2.3.4 and later where app:config:import may fail if cache:flush is not run immediately prior ([issue #138](https://github.com/davidalger/capistrano-magento2/issues/138))

See CHANGELOG for upgrade notes: https://github.com/davidalger/capistrano-magento2/blob/master/CHANGELOG.md#090