### PR TITLE
Add :magento_deploy_deterministic_content_version option

### DIFF
--- a/lib/capistrano/magento2/defaults.rb
+++ b/lib/capistrano/magento2/defaults.rb
@@ -56,6 +56,7 @@ set :magento_deploy_no_dev, fetch(:magento_deploy_no_dev, true)
 set :magento_deploy_themes, fetch(:magento_deploy_themes, [])
 set :magento_deploy_jobs, fetch(:magento_deploy_jobs, nil)
 set :magento_deploy_strategy, fetch(:magento_deploy_strategy, nil)
+set :magento_deploy_deterministic_content_version, fetch(:magento_deploy_deterministic_content_version, false)
 
 # deploy targetting defaults
 set :magento_deploy_setup_role, fetch(:magento_deploy_setup_role, :all)

--- a/lib/capistrano/tasks/magento.rake
+++ b/lib/capistrano/tasks/magento.rake
@@ -359,8 +359,15 @@ namespace :magento do
               compilation_strategy =  " -s #{compilation_strategy}"
             end
 
+            deterministic_content_version = fetch(:magento_deploy_deterministic_content_version)
+            if deterministic_content_version
+              content_version = " --content-version=#{fetch(:release_timestamp)}"
+            else
+              content_version = nil
+            end
+
             within release_path do
-              execute :magento, "setup:static-content:deploy#{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}"
+              execute :magento, "setup:static-content:deploy#{compilation_strategy}#{deploy_jobs}#{deploy_languages}#{deploy_themes}#{content_version}"
             end
 
             # Set the deployed_version of static content to ensure it matches across all hosts


### PR DESCRIPTION
The `:magento_deploy_deterministic_content_version` flag, when set to `true`, runs `setup:static-content:deploy` with `--content-version=<release_timestamp>`.

It is intended to resolve missing CSS and JS (especially when merging is enabled) on mult-server deployments, by providing a deterministic content version, i.e. ensuring that CSS and JS file paths and filenames are exactly the same on all servers.